### PR TITLE
Add draft blog posts summarizing tutorials

### DIFF
--- a/blog_drafts/agents_tutorial_blog_post_draft.md
+++ b/blog_drafts/agents_tutorial_blog_post_draft.md
@@ -1,0 +1,26 @@
+# Building Robust LangGraph Agents
+
+The **02-Agents** portion of LangGraph 101 dives into creating autonomous and collaborative agents. Each tutorial showcases different patterns for managing state, streaming outputs, and coordinating multiple agents.
+
+## Running Agents
+Start with the fundamentals of agent execution. Examples cover synchronous and asynchronous runs, streaming tokens, and recursion limits.
+
+## Agent State
+These tutorials explore how to track tasks and maintain conversation context across steps, even when several agents share information.
+
+## Streaming Responses
+Learn about multiple streaming modes, from simple token streaming to tool update streams. Examples show how to combine streaming techniques for responsive apps.
+
+## Tools
+The tools tutorial explains how to build and customize function tools, handle errors gracefully, and leverage advanced features like hidden arguments or forced tool use.
+
+## Human-in-the-Loop
+For workflows that require manual oversight, you’ll see patterns for basic approval and intermediate editing workflows.
+
+## Multi-Agent Workflows
+LangGraph supports coordinating multiple agents. Examples demonstrate sequential collaborations, supervisor-worker delegation, and even debates among agents.
+
+## Advanced Examples and RAG
+To round things out, the tutorials include advanced agent patterns and a Retrieval-Augmented Generation agent that lets you chat with your own documents.
+
+Together these lessons provide a comprehensive look at constructing intelligent agents with LangGraph.

--- a/blog_drafts/apps_tutorial_blog_post_draft.md
+++ b/blog_drafts/apps_tutorial_blog_post_draft.md
@@ -1,0 +1,14 @@
+# Real‑World Examples with LangGraph
+
+After mastering graphs and agents, the **03-Apps** directory shows how to assemble full applications. Each subfolder contains a focused project that demonstrates LangGraph in a specific domain.
+
+## Travel Planning Agent
+This agent coordinates flights, hotels, and activities to build multi-city itineraries. It factors in user preferences, budgets, and even weather forecasts to generate an optimized trip plan.
+
+## Finance & Investment Agent
+A sophisticated assistant for tracking expenses, managing budgets, fetching market data, and analyzing portfolios. The workflow combines multiple tools and state management techniques to hold conversations about personal finance.
+
+## Additional Applications
+Other examples include customer support bots, medical appointment scheduling, smart home automation, developer assistants, legal document analysis, content creation pipelines, research summarization, and more. Each project illustrates how to adapt LangGraph patterns to different use cases.
+
+Exploring these apps will spark ideas for your own LangGraph projects.

--- a/blog_drafts/graphs_tutorial_blog_post_draft.md
+++ b/blog_drafts/graphs_tutorial_blog_post_draft.md
@@ -1,0 +1,20 @@
+# Exploring LangGraph Graphs
+
+LangGraph makes it simple to build stateful workflows around large language models. The **01-Graphs** tutorials walk through the essential features step by step.
+
+## Graph Basics
+These examples introduce the `StateGraph` concept and show how to define a state schema, create nodes, and compile a graph into a runnable application. The tutorial culminates in a tiny graph that greets the user.
+
+## Handling Multiple Inputs
+Next, you'll see how to design a graph that consumes several pieces of state at once. The example grade calculator demonstrates reading multiple fields from the state to perform a computation, and how to visualize the graph.
+
+## Conditional Routing
+Here we learn how router functions can alter the flow depending on the state. The conditional routing examples show both number processing and text processing workflows that take different branches based on custom logic.
+
+## Looping Logic
+LangGraph also supports loops. You'll experiment with looping directly back to a node or using a decision node to break out once a condition is met. The tutorial adds random numbers to a list until a threshold is reached, generating diagrams for each approach.
+
+## Basic Chat Graph
+Finally, all of the concepts come together in a simple command line chat app. The state tracks conversation history while nodes parse user input, generate LLM responses, and handle commands like `exit` or `verbose`.
+
+These tutorials form the foundation for building more complex LangGraph applications.


### PR DESCRIPTION
## Summary
- create `blog_drafts/` directory
- add draft posts for the `01-Graphs`, `02-Agents`, and `03-Apps` tutorials

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888f665ccb4832abf167bf1ed363a39

## Summary by Sourcery

Add initial draft blog posts for each LangGraph 101 tutorial under a new blog_drafts directory.

Documentation:
- Add draft post summarizing the 01-Graphs tutorial
- Add draft post summarizing the 02-Agents tutorial
- Add draft post summarizing the 03-Apps tutorial